### PR TITLE
Fixed wrong typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,22 @@
       "integrity": "sha1-4ZQ25/jptGAQBdc2c7bcR4T/zC8=",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "acorn": {
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/daimler-mic/_packaging/mercedes-developer-experience/npm/registry/acorn/-/acorn-7.0.0.tgz",
@@ -87,6 +103,12 @@
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
       "dev": true
     },
     "escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^16.9.0"
   },
   "devDependencies": {
+    "@types/react": "^16.9.17",
     "react": "^16.9.0",
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,21 +19,21 @@ const reactifyWebComponent = (WC: string) => {
           return undefined;
         }
         if (prop.toLowerCase() === "classname") {
-          return (this.ref.current.className = val);
+          return (this.ref.current.className = val as string);
         }
         if (typeof val === "function" && prop.match(/^on[A-Z]/)) {
           const event = prop[2].toLowerCase() + prop.substr(3);
           this.eventHandlers.push([event, val]);
-          return this.ref.current.addEventListener(event, val);
+          return this.ref.current.addEventListener(event, val as EventListener);
         }
         if (typeof val === "string" || typeof val === "number") {
           this.ref.current[prop] = val;
-          return this.ref.current.setAttribute(prop, val);
+          return this.ref.current.setAttribute(prop, String(val));
         }
         if (typeof val === "boolean") {
           if (val) {
             this.ref.current[prop] = true;
-            return this.ref.current.setAttribute(prop, val);
+            return this.ref.current.setAttribute(prop, String(val));
           }
           delete this.ref.current[prop];
           return this.ref.current.removeAttribute(prop);
@@ -57,7 +57,7 @@ const reactifyWebComponent = (WC: string) => {
 
     clearEventHandlers() {
       this.eventHandlers.forEach(([event, handler]) => {
-        this.ref.current.removeEventListener(event, handler);
+        this.ref.current.removeEventListener(event, handler as EventListener);
       });
       this.eventHandlers = [];
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,12 @@ const reactifyWebComponent = (WC: string) => {
         }
         if (typeof val === "string" || typeof val === "number") {
           this.ref.current[prop] = val;
-          return this.ref.current.setAttribute(prop, String(val));
+          return this.ref.current.setAttribute(prop, val as string);
         }
         if (typeof val === "boolean") {
           if (val) {
             this.ref.current[prop] = true;
-            return this.ref.current.setAttribute(prop, String(val));
+            return this.ref.current.setAttribute(prop, val as unknown as string);
           }
           delete this.ref.current[prop];
           return this.ref.current.removeAttribute(prop);


### PR DESCRIPTION
This PR fixes typings for React typescript projects. Without typings typescript can't infer types correctly. 
Without typings:

![image](https://user-images.githubusercontent.com/21972165/71296033-84daba80-237e-11ea-8f24-55e6f744ebaa.png)

With typings:

![image](https://user-images.githubusercontent.com/21972165/71296050-91f7a980-237e-11ea-9dfc-3eecc7d2627f.png)

