### PR TITLE
add alwaysSetProperty param to reactifyWebComponent() to force property

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ const Example = () => (
 Events passed into the event handlers are browser events, not React
 SyntheticEvents.
 
+## Forcing props to be set as Properties
+
+Should you wish to override the default type heuristic and ensure a prop is set as
+a DOM property, you can pass an array of the prop names as the optional second parameter to `reactifyWC()`
+
+```jsx
+import React from "react";
+import reactifyWc from "reactify-wc";
+
+// Import your web component. This one defines a tag called 'my-element'
+import "my-element";
+
+const VaadinButton = reactifyWc("my-element", ["setMeAsAProp"]);
+
+export const MyReactComponent = () => (
+  <>
+    <h1>Hello world</h1>
+    <MyElement setMeAsAProp={"value"}>Click me!</MyElement>
+  </>
+);
+```
+
+
 # Composability Details
 
 Many web components are "composable," meaning that in order to get a desired

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { RefObject, Component, createRef, createElement, ReactNode } from "react";
 
-const reactifyWebComponent = <Props>(WC: string) => {
+const reactifyWebComponent = <Props>(WC: string, alwaysSetProperty: string[] = []) => {
   return class extends Component {
     props: Props & { children?: ReactNode };
     eventHandlers: [string, Function][];
@@ -21,30 +21,32 @@ const reactifyWebComponent = <Props>(WC: string) => {
         if (prop.toLowerCase() === "classname") {
           return (this.ref.current.className = val as string);
         }
-        if (typeof val === "function" && prop.match(/^on[A-Z]/)) {
-          const event = prop[2].toLowerCase() + prop.substr(3);
-          this.eventHandlers.push([event, val]);
-          return this.ref.current.addEventListener(event, val as EventListener);
-        }
-        if (typeof val === "function" && prop.match(/^on\-[a-z]/)) {
-          const event = prop.substr(3);
-          this.eventHandlers.push([event, val]);
-          return this.ref.current.addEventListener(event, val as EventListener);
-        }
-        if (typeof val === "string" || typeof val === "number") {
-          this.ref.current[prop] = val;
-          return this.ref.current.setAttribute(prop, val as string);
-        }
-        if (typeof val === "boolean") {
-          if (val) {
-            this.ref.current[prop] = true;
-            return this.ref.current.setAttribute(
-              prop,
-              (val as unknown) as string
-            );
+        if(!alwaysSetProperty.includes(prop)) {
+          if (typeof val === "function" && prop.match(/^on[A-Z]/)) {
+            const event = prop[2].toLowerCase() + prop.substr(3);
+            this.eventHandlers.push([event, val]);
+            return this.ref.current.addEventListener(event, val as EventListener);
           }
-          delete this.ref.current[prop];
-          return this.ref.current.removeAttribute(prop);
+          if (typeof val === "function" && prop.match(/^on\-[a-z]/)) {
+            const event = prop.substr(3);
+            this.eventHandlers.push([event, val]);
+            return this.ref.current.addEventListener(event, val as EventListener);
+          }
+          if (typeof val === "string" || typeof val === "number") {
+            this.ref.current[prop] = val;
+            return this.ref.current.setAttribute(prop, val as string);
+          }
+          if (typeof val === "boolean") {
+            if (val) {
+              this.ref.current[prop] = true;
+              return this.ref.current.setAttribute(
+                prop,
+                (val as unknown) as string
+              );
+            }
+            delete this.ref.current[prop];
+            return this.ref.current.removeAttribute(prop);
+          }
         }
         this.ref.current[prop] = val;
         return undefined;


### PR DESCRIPTION
There are times when you wish to avoid the type heuristic and always set a property. Added an optional array of prop names which will always get set as a property regardless of value type.

This is useful where WCs expose only a property, or expose callback functions beginning with `onX` rather than fire events.
One example is providing an access token or secret to a component where exposing via an attribute could lead to [XSS attacks via CSS](https://www.mike-gualtieri.com/posts/stealing-data-with-css-attack-and-defense).
