### PR TITLE
Allow style object to be passed down, and ref to reference the actual element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reactify-wc",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,6 +28,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.0.tgz",
       "integrity": "sha512-jnm//T5ZWOZ6zmJ61fReSCBOif+Ax8dHVoVggA+d2NA7T4qCWgQ3KYr+zN2faGEYLpe1wa03IzvhR+sqVLxUWg==",
+      "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.0",
         "estree-walker": "^0.6.1",
@@ -40,6 +41,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.1.tgz",
       "integrity": "sha512-PmNurkecagFimv7ZdKCVOfQuqKDPkrcpLFxRBcQ00LYr4HAjJwhCFxBiY2Xoletll2htTIiXBg6g0Yg21h2M3w==",
+      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       }
@@ -47,7 +49,8 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/node": {
       "version": "13.11.0",
@@ -139,7 +142,8 @@
     "estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -174,6 +178,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
       "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
       }
@@ -227,6 +232,7 @@
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
       "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -246,7 +252,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "prop-types": {
       "version": "15.7.2",
@@ -280,6 +287,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -354,7 +362,8 @@
     "sourcemap-codec": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   createRef,
   createElement,
   ReactNode,
+  forwardRef,
 } from "react";
 import { Options } from "./types";
 
@@ -15,15 +16,19 @@ const reactifyWebComponent = <Props>(
     forceEvent: [],
   }
 ) => {
-  return class extends Component {
-    props: Props & { style?: Object; children?: ReactNode };
+  class Reactified extends Component {
+    props: Props & {
+      innerRef?: RefObject<HTMLElement>;
+      style?: Object;
+      children?: ReactNode;
+    };
     eventHandlers: [string, Function][];
     ref: RefObject<HTMLElement>;
 
     constructor(props) {
       super(props);
       this.eventHandlers = [];
-      this.ref = createRef<HTMLElement>();
+      this.ref = this.props.innerRef || createRef<HTMLElement>();
     }
 
     setProperty(prop: string, val: any) {
@@ -112,7 +117,11 @@ const reactifyWebComponent = <Props>(
       const { children, style } = this.props;
       return createElement(WC, { ref: this.ref, style }, children);
     }
-  };
+  }
+
+  return forwardRef(({ children, ...props }, ref) =>
+    createElement(Reactified, { innerRef: ref, ...props }, children)
+  );
 };
 
 export default reactifyWebComponent;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const reactifyWebComponent = <Props>(
   }
 ) => {
   return class extends Component {
-    props: Props & { children?: ReactNode };
+    props: Props & { style?: Object; children?: ReactNode };
     eventHandlers: [string, Function][];
     ref: RefObject<HTMLElement>;
 
@@ -59,7 +59,7 @@ const reactifyWebComponent = <Props>(
           forced = true;
         }
         if (forced) return;
-
+        if (prop === "style") return;
         // We haven't forced the type, so determine the correct typing and
         // assign the value to the right place
         if (prop === "children") {
@@ -109,8 +109,8 @@ const reactifyWebComponent = <Props>(
     }
 
     render() {
-      const { children } = this.props;
-      return createElement(WC, { ref: this.ref }, children);
+      const { children, style } = this.props;
+      return createElement(WC, { ref: this.ref, style }, children);
     }
   };
 };

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -11913,9 +11913,6 @@
     },
     "reactify-wc": {
       "version": "file:..",
-      "requires": {
-        "@rollup/plugin-commonjs": "^11.0.0"
-      },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.5.5",

--- a/test/src/Tests.js
+++ b/test/src/Tests.js
@@ -12,6 +12,7 @@ import "./webComponents/PropertyTest";
 import "./webComponents/ChildrenTest";
 import "./webComponents/EventTest";
 import "./webComponents/StyleTest";
+import "./webComponents/RefTest";
 
 const StringTest = reactify("string-test");
 const BooleanTest = reactify("boolean-test");
@@ -26,11 +27,14 @@ const EventTestForceEvent = reactify("event-test", {
   forceEvent: ["thing"],
 });
 const StyleTest = reactify("style-test");
+const RefTest = reactify("ref-test");
 
 class Tests extends PureComponent {
   constructor() {
     super();
+    this.ref = React.createRef(null);
     this.state = {
+      ref: null,
       string: "Bryce",
       boolean: true,
       number: 123,
@@ -137,6 +141,20 @@ class Tests extends PureComponent {
             <div className="component">
               <h3>Style Test</h3>
               <StyleTest style={{ color: "red" }}>Text has red color</StyleTest>
+            </div>
+            <div className="component">
+              <h3>Ref Test</h3>
+              <RefTest ref={this.ref}></RefTest>
+              <p>Check that ref.current.tagName is REF-TEST</p>
+              <Button
+                onClick={() => {
+                  this.setState({
+                    ref: this.ref.current.tagName,
+                  });
+                }}
+              >
+                Check ref!
+              </Button>
             </div>
           </div>
           <div className="row">

--- a/test/src/Tests.js
+++ b/test/src/Tests.js
@@ -11,6 +11,7 @@ import "./webComponents/NumberTest";
 import "./webComponents/PropertyTest";
 import "./webComponents/ChildrenTest";
 import "./webComponents/EventTest";
+import "./webComponents/StyleTest";
 
 const StringTest = reactify("string-test");
 const BooleanTest = reactify("boolean-test");
@@ -24,6 +25,7 @@ const EventTest = reactify("event-test");
 const EventTestForceEvent = reactify("event-test", {
   forceEvent: ["thing"],
 });
+const StyleTest = reactify("style-test");
 
 class Tests extends PureComponent {
   constructor() {
@@ -129,6 +131,12 @@ class Tests extends PureComponent {
               >
                 Toggle Child!
               </Button>
+            </div>
+          </div>
+          <div className="row">
+            <div className="component">
+              <h3>Style Test</h3>
+              <StyleTest style={{ color: "red" }}>Text has red color</StyleTest>
             </div>
           </div>
           <div className="row">

--- a/test/src/webComponents/RefTest.js
+++ b/test/src/webComponents/RefTest.js
@@ -1,0 +1,20 @@
+export class RefTest extends HTMLElement {
+  static get template() {
+    const temp = document.createElement("template");
+    temp.innerHTML = `<p></p>`;
+    return temp;
+  }
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.appendChild(RefTest.template.content.cloneNode(true));
+  }
+}
+
+window.customElements.define("ref-test", RefTest);
+export const RefTestElement = () => document.createElement("ref-test");
+export default RefTestElement;

--- a/test/src/webComponents/StyleTest.js
+++ b/test/src/webComponents/StyleTest.js
@@ -1,0 +1,22 @@
+export class StyleTest extends HTMLElement {
+  static get template() {
+    const temp = document.createElement("template");
+    temp.innerHTML = `
+    <p><slot></slot></p>
+    `;
+    return temp;
+  }
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.appendChild(StyleTest.template.content.cloneNode(true));
+  }
+}
+
+window.customElements.define("style-test", StyleTest);
+export const StyleTestElement = () => document.createElement("style-test");
+export default StyleTestElement;


### PR DESCRIPTION
Fixes #8 

Also uses a [forwardRef](https://reactjs.org/docs/forwarding-refs.html) to make refs point to the actual custom element and not the React wrapper.