### PR TITLE
pass on type info for props to forwardref to make typescript work for own props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import {
   Component,
   createRef,
   createElement,
-  ReactNode,
   forwardRef,
+  PropsWithChildren,
 } from "react";
 import { Options } from "./types";
 
@@ -17,10 +17,9 @@ const reactifyWebComponent = <Props>(
   }
 ) => {
   class Reactified extends Component {
-    props: Props & {
+    props: PropsWithChildren<Props> & {
       innerRef?: RefObject<HTMLElement>;
       style?: Object;
-      children?: ReactNode;
     };
     eventHandlers: [string, Function][];
     ref: RefObject<HTMLElement>;
@@ -119,7 +118,8 @@ const reactifyWebComponent = <Props>(
     }
   }
 
-  return forwardRef(({ children, ...props }, ref) =>
+  return forwardRef<{innerRef?: RefObject<HTMLElement>}, PropsWithChildren<Props> & {style?: Object}>
+  (({ children, ...props }, ref) =>
     createElement(Reactified, { innerRef: ref, ...props }, children)
   );
 };


### PR DESCRIPTION
Quick fix for typescript to solve issue with own props: https://github.com/BBKolton/reactify-wc/issues/15. 

All seems to be working in the test-app.
I know that https://github.com/BBKolton/reactify-wc/pull/17 will fix this issue, but not sure when it would be done, so I thought it would be nice to just do this on it's own as it's probably is affecting a few people. @BBKolton 